### PR TITLE
Various quality of life fixes

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -29,9 +29,9 @@ main = do
   -- Set the constraint
   glp_set_row_bnds problem row glpkLT 0.1 4
 
-  indices <- mkGlpkArray [x_index, y_index]
+  indices <- mallocGlpkArray [x_index, y_index]
 
-  coefs <- mkGlpkArray [1.0, 1.0]
+  coefs <- mallocGlpkArray [1.0, 1.0]
   glp_set_mat_row problem row 2 indices coefs
   free (fromGlpkArray indices)
   free (fromGlpkArray coefs)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -33,8 +33,8 @@ main = do
 
   coefs <- mkGlpkArray [1.0, 1.0]
   glp_set_mat_row problem row 2 indices coefs
-  free (fromGplkArray indices)
-  free (fromGplkArray coefs)
+  free (fromGlpkArray indices)
+  free (fromGlpkArray coefs)
 
   glp_set_col_bnds problem x_index glpkBounded 1 8
   glp_set_col_bnds problem y_index glpkBounded 0 10

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -36,8 +36,8 @@ main = do
   free (fromGplkArray indices)
   free (fromGplkArray coefs)
 
-  glp_set_col_bnds problem x_index glpkEQ 1 8
-  glp_set_col_bnds problem y_index glpkEQ 0 10
+  glp_set_col_bnds problem x_index glpkBounded 1 8
+  glp_set_col_bnds problem y_index glpkBounded 0 10
 
   glp_set_obj_coef problem x_index 2.0
   glp_set_obj_coef problem y_index 0.5

--- a/src/Math/Programming/Glpk/Header.hsc
+++ b/src/Math/Programming/Glpk/Header.hsc
@@ -56,8 +56,11 @@ newtype GlpkInt a
   deriving
     ( Enum
     , Eq
+    , Integral
+    , Num
     , Ord
     , Read
+    , Real
     , Show
     , Storable
     )

--- a/src/Math/Programming/Glpk/Header.hsc
+++ b/src/Math/Programming/Glpk/Header.hsc
@@ -1383,7 +1383,7 @@ newtype GlpkConstraintType
  , glpkFree = GLP_FR
  , glpkGT = GLP_LO
  , glpkLT = GLP_UP
- , glpkEQ = GLP_DB
+ , glpkBounded = GLP_DB
  , glpkFixed = GLP_FX
  }
 

--- a/src/Math/Programming/Glpk/Header.hsc
+++ b/src/Math/Programming/Glpk/Header.hsc
@@ -20,7 +20,7 @@ data Problem
 
 -- | An array whose data begins at index 1
 newtype GlpkArray a
-  = GlpkArray { fromGplkArray :: Ptr a }
+  = GlpkArray { fromGlpkArray :: Ptr a }
   deriving
     ( Eq
     , Ord

--- a/src/Math/Programming/Glpk/Header.hsc
+++ b/src/Math/Programming/Glpk/Header.hsc
@@ -47,8 +47,12 @@ initializeGlpkArray xs array =
     pokeArray (plusPtr array elemSize) xs
     return (GlpkArray array)
 
-newtype Column
-  = Column { fromColumn :: CInt}
+data GlpkColumn
+
+data GlpkRow
+
+newtype GlpkInt a
+  = GlpkInt { fromGlpkInt :: CInt }
   deriving
     ( Enum
     , Eq
@@ -58,16 +62,9 @@ newtype Column
     , Storable
     )
 
-newtype Row
-  = Row { fromRow :: CInt}
-  deriving
-    ( Enum
-    , Eq
-    , Ord
-    , Read
-    , Show
-    , Storable
-    )
+type Row = GlpkInt GlpkRow
+
+type Column = GlpkInt GlpkColumn
 
 foreign import ccall "glp_create_prob" glp_create_prob
   :: IO (Ptr Problem)

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-12.2
+resolver: lts-12.5
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
This MR:

1. Unifies rows and columns behind a tagged `GlpkInt` type
1. Introduces safer use 1-based arrays through `mallocGlpkArray` and `allocaGlpkArray`
1. Changes `glpkEQ` to `glpkBounded`, as `glpkEQ` was misleading