### PR TITLE
Speed up CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,19 +3,13 @@ name: CI
 on: push
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
+    container: prsteele/stack-build-glpk:v1-8.6.5
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Build
-        uses: prsteele/stack-build-glpk-action@v1
-        with:
-          commands: stack --stack-root /home/stackage --allow-different-user build --pedantic
-
       - name: Test
-        uses: prsteele/stack-build-glpk-action@v1
-        with:
-          commands: stack --stack-root /home/stackage --allow-different-user test --pedantic
+        run: stack --allow-different-user test --pedantic


### PR DESCRIPTION
We use a pre-built container image and remove a redundant build step.