### PR TITLE
describe required GLPK version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ Comprehensive Haskell bindings to
 [GLPK](https://www.gnu.org/software/glpk/). No attempt is made to make
 these bindings conform to Haskell norms --- they are a direct
 translation from the GLPK header file.
+
+## Requirements
+
+* GLPK >=4.62


### PR DESCRIPTION
How about describing the required GLPK version in `README.md`?

I encountered linking errors when I compiled it with `glpk-4.57`: `glp_mpl_init_rand` and `glp_config` were undefined.

According to the ChangeLog of GLPK:
* `glp_mpl_init_rand` was introduced in GLPK 4.58,
* `glp_config()` was introduced in GLPK 4.61 and the symbol was added to `def` files in 4.62.

So I guess the requirement is GLPK >=4.62.