### PR TITLE
move 'extra-libraries' section to 'library' stanza

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -21,6 +21,8 @@ dependencies:
 
 library:
   source-dirs: src
+  extra-libraries:
+    - glpk
 
 tests:
   GlpkHs-test:
@@ -30,8 +32,6 @@ tests:
       - -threaded
       - -rtsopts
       - -with-rtsopts=-N
-    extra-libraries:
-      - glpk
     dependencies:
       - glpk-headers
       - tasty


### PR DESCRIPTION
Originally every executable that uses the library is required to have `extra-libraries` to link 'glpk' library, but it is unnecessary if we have `extra-libraries` section in `library` stanza.