### PR TITLE
Update glpk-headers-haskell.cabal

### DIFF
--- a/glpk-headers-haskell.cabal
+++ b/glpk-headers-haskell.cabal
@@ -31,7 +31,6 @@ test-suite glpk-headers-haskell-test-suite
   main-is:           Driver.hs
   hs-source-dirs:    test
   ghc-options:       -threaded -with-rtsopts=-N
-  extra-libraries:   glpk
   other-modules:     Diet
   build-depends:     base
                    , glpk-headers-haskell


### PR DESCRIPTION
removed from test-suite stanza:
  Extra-Libraries: glpk

duplicate with library stanza since 8d027751a5884d3aa712c014d9142559aea5a554